### PR TITLE
Use aliased resource imports in controllers

### DIFF
--- a/src/Generators/ControllerGenerator.php
+++ b/src/Generators/ControllerGenerator.php
@@ -140,12 +140,16 @@ class ControllerGenerator implements Generator
                 } elseif ($statement instanceof ResourceStatement) {
                     $fqcn = config('blueprint.namespace').'\\Http\\Resources\\'.($controller->namespace() ? $controller->namespace().'\\' : '').$statement->name();
 
-                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return \\'.$fqcn, $method);
-
                     $import = $fqcn;
+
                     if (!$statement->collection()) {
-                        $import .= ' as '.$statement->name().'Resource';
+                        $fqcn = $statement->name().'Resource';
+                        $import .= ' as '.$fqcn;
+                    } else {
+                        $fqcn = "\\{$fqcn}";
                     }
+
+                    $method = str_replace('* @return \\Illuminate\\Http\\Response', '* @return '.$fqcn, $method);
 
                     $this->addImport($controller, $import);
 

--- a/tests/fixtures/controllers/api-routes-example.php
+++ b/tests/fixtures/controllers/api-routes-example.php
@@ -25,7 +25,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\Api\CertificateStoreRequest $request
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -37,7 +37,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -47,7 +47,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\Api\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Api\Certificate
+     * @return CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-controller.php
+++ b/tests/fixtures/controllers/certificate-controller.php
@@ -24,7 +24,7 @@ class CertificateController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateStoreRequest $request
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function store(CertificateStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function show(Request $request, Certificate $certificate)
     {
@@ -46,7 +46,7 @@ class CertificateController extends Controller
     /**
      * @param \App\Http\Requests\CertificateUpdateRequest $request
      * @param \App\Certificate $certificate
-     * @return \App\Http\Resources\Certificate
+     * @return CertificateResource
      */
     public function update(CertificateUpdateRequest $request, Certificate $certificate)
     {

--- a/tests/fixtures/controllers/certificate-type-controller.php
+++ b/tests/fixtures/controllers/certificate-type-controller.php
@@ -24,7 +24,7 @@ class CertificateTypeController extends Controller
 
     /**
      * @param \App\Http\Requests\CertificateTypeStoreRequest $request
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function store(CertificateTypeStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\CertificateType $certificateType
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function show(Request $request, CertificateType $certificateType)
     {
@@ -46,7 +46,7 @@ class CertificateTypeController extends Controller
     /**
      * @param \App\Http\Requests\CertificateTypeUpdateRequest $request
      * @param \App\CertificateType $certificateType
-     * @return \App\Http\Resources\CertificateType
+     * @return CertificateTypeResource
      */
     public function update(CertificateTypeUpdateRequest $request, CertificateType $certificateType)
     {

--- a/tests/fixtures/controllers/custom-models-namespace.php
+++ b/tests/fixtures/controllers/custom-models-namespace.php
@@ -24,7 +24,7 @@ class TagController extends Controller
 
     /**
      * @param \App\Http\Requests\TagStoreRequest $request
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function store(TagStoreRequest $request)
     {
@@ -36,7 +36,7 @@ class TagController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\Models\Tag $tag
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function show(Request $request, Tag $tag)
     {
@@ -46,7 +46,7 @@ class TagController extends Controller
     /**
      * @param \App\Http\Requests\TagUpdateRequest $request
      * @param \App\Models\Tag $tag
-     * @return \App\Http\Resources\Tag
+     * @return TagResource
      */
     public function update(TagUpdateRequest $request, Tag $tag)
     {

--- a/tests/fixtures/controllers/resource-statements.php
+++ b/tests/fixtures/controllers/resource-statements.php
@@ -20,7 +20,7 @@ class UserController extends Controller
 
     /**
      * @param \Illuminate\Http\Request $request
-     * @return \App\Http\Resources\User
+     * @return UserResource
      */
     public function store(Request $request)
     {
@@ -30,7 +30,7 @@ class UserController extends Controller
     /**
      * @param \Illuminate\Http\Request $request
      * @param \App\User $user
-     * @return \App\Http\Resources\User
+     * @return UserResource
      */
     public function show(Request $request, User $user)
     {


### PR DESCRIPTION
That way resources do not need to be imported twice: via FQCN and inline import.

cc: @jasonmccreary I can't seem to have dependent PRs in your repository. Once https://github.com/laravel-shift/blueprint/issues/330 gets merged, I can open the PR there. This is just so you can have a look at it beforehand.

related to: https://github.com/laravel-shift/blueprint/issues/329